### PR TITLE
Wwise Integration Issue

### DIFF
--- a/HBO/HBO.uproject
+++ b/HBO/HBO.uproject
@@ -10,6 +10,10 @@
 			"TargetAllowList": [
 				"Editor"
 			]
+		},
+		{
+			"Name": "WwiseNiagara",
+			"Enabled": false
 		}
 	]
 }


### PR DESCRIPTION
Disabled Wwise Niagara plugin to avoid missing .dll and .lib file errors.